### PR TITLE
fix add user

### DIFF
--- a/pkg/secrets/mount.go
+++ b/pkg/secrets/mount.go
@@ -2,7 +2,6 @@ package secrets
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -81,31 +80,6 @@ func readTargetFile(path string) (map[string]string, error) {
 	}
 
 	return users, nil
-}
-
-// Creates a directory on the local filesystem at the path:
-// {path}/{secret}
-func CreateSecretsDirectory(path string, secret string) error {
-	secretPath := fmt.Sprintf("%v/%v", path, secret)
-	err := os.MkdirAll(secretPath, 0750)
-	if err != nil && !os.IsExist(err) {
-		return err
-	}
-	return nil
-}
-
-// Writes key-values for a kubernetes secret to path {path}/{secret} whee each key
-// is its own file whose contents is the value of the key i.e. filename = key, file = value
-func WriteSecretsKeyValue(path string, secret string, key string, value string) error {
-	f, err := os.Create(fmt.Sprintf("%s/%s/%s", path, secret, key))
-	if err != nil {
-		return err
-	}
-
-	defer f.Close()
-
-	_, err = f.WriteString(value)
-	return err
 }
 
 func readFile(path string) (string, error) {

--- a/pkg/secrets/mount.go
+++ b/pkg/secrets/mount.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"bufio"
+	"fmt"
 	"io"
 	"io/fs"
 	"os"
@@ -81,8 +82,6 @@ func readTargetFile(path string) (map[string]string, error) {
 
 	return users, nil
 }
-<<<<<<< Updated upstream
-=======
 
 // Creates a directory on the local filesystem at the path:
 // {path}/{secret}
@@ -124,4 +123,3 @@ func readFile(path string) (string, error) {
 
 	return string(fileContents), nil
 }
->>>>>>> Stashed changes

--- a/pkg/secrets/mount.go
+++ b/pkg/secrets/mount.go
@@ -40,25 +40,13 @@ func readTargetSecretMount(path string) (map[string]string, error) {
 			return nil
 		}
 
-		// We should have two keys here: username and password and use that information..
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-
-		defer f.Close()
-
-		fileContents, err := io.ReadAll(f)
-		if err != nil {
-			return err
-		}
-		data := string(fileContents)
-
 		switch d.Name() {
 		case "password":
-			password = data
+			password, err = readFile(path)
+			return err
 		case "username":
-			username = data
+			username, err = readFile(path)
+			return err
 		}
 
 		return nil
@@ -93,3 +81,47 @@ func readTargetFile(path string) (map[string]string, error) {
 
 	return users, nil
 }
+<<<<<<< Updated upstream
+=======
+
+// Creates a directory on the local filesystem at the path:
+// {path}/{secret}
+func CreateSecretsDirectory(path string, secret string) error {
+	secretPath := fmt.Sprintf("%v/%v", path, secret)
+	err := os.MkdirAll(secretPath, 0750)
+	if err != nil && !os.IsExist(err) {
+		return err
+	}
+	return nil
+}
+
+// Writes key-values for a kubernetes secret to path {path}/{secret} whee each key
+// is its own file whose contents is the value of the key i.e. filename = key, file = value
+func WriteSecretsKeyValue(path string, secret string, key string, value string) error {
+	f, err := os.Create(fmt.Sprintf("%s/%s/%s", path, secret, key))
+	if err != nil {
+		return err
+	}
+
+	defer f.Close()
+
+	_, err = f.WriteString(value)
+	return err
+}
+
+func readFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+
+	defer f.Close()
+
+	fileContents, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+
+	return string(fileContents), nil
+}
+>>>>>>> Stashed changes


### PR DESCRIPTION
add-user in the cli was failing when reading a directory. If it's in a directory, just look for files that are named `username` or `password` as this is the secret mounting format that will be followed